### PR TITLE
Fix the tags for all posts with multiple tags

### DIFF
--- a/source/_posts/evil-mode-pt-1.md
+++ b/source/_posts/evil-mode-pt-1.md
@@ -1,7 +1,10 @@
 ---
 title: Evil-mode (Part 1)
 date: 2013-01-14
-tags: editors clojure evil-mode
+tags: 
+- editors 
+- clojure 
+- evil-mode
 ---
 
 I've been using [vim](http://www.vim.org/) for the last 4 years regularly as my text editor, and in many ways, vim has permiated all the other tools I use. In any application that I can, I will use vi/vim bindings if they are offered. I use vi-mode emulation in my terminal shell, [zsh](http://www.zsh.org/). I use a vim emulation layer in [Firefox](http://getfirefox.com/) called [Pentadactyl](http://5digits.org/pentadactyl/). I use a pdf reader called [mupdf](http://www.mupdf.com/) that has vim bindings, and the list goes on. Since learning the programming language [Clojure](http://clojure.org/), though, I've been interested in learning the text editor [emacs](http://www.gnu.org/s/emacs/), as there are a lot of Clojure tools designed around emacs. I still have no idea what I'm doing, nonetheless...

--- a/source/_posts/htpc-pt1.md
+++ b/source/_posts/htpc-pt1.md
@@ -1,7 +1,9 @@
 ---
 title: HTPC Build - Part 1 - Hardware
 date: 2013-08-22
-tags: htpc hardware
+tags: 
+- htpc 
+- hardware
 ---
 
 I'm finishing up my yearly summer stint here in [Craig, AK](http://en.wikipedia.org/wiki/Craig,_Alaska), and I thought it might be a good time to actually build that [Home Theater PC](http://en.wikipedia.org/wiki/Home_theater_PC) that I've been dreaming about for the last 3-4 years. For those unfamiliar with HTPCs, the basic idea is to have an all-in-one computer that is good for all media duties that you may have relating to your television. In my case, that means being able to watch movies and TV shows from many sources, including [Netflix](http://www.netflix.com) and [Hulu](http://www.hulu.com) (because I don't have cable), as well as being able to play videogames, both [old](https://en.wikipedia.org/wiki/List_of_video_game_emulators) and [new](http://www.tombraider2013.com/). As I said above, this has been a dream of mine for a few years, and after seeing [Sauerkrause's build](http://random-sequential.blogspot.com/2013/08/gaminghtpc-build-hardware.html), I felt the need to finally spend some of my hard-earned money and commit to the project.

--- a/source/_posts/mopidy-subsonic.md
+++ b/source/_posts/mopidy-subsonic.md
@@ -1,7 +1,11 @@
 ---
 title: Mopidy-Subsonic
 date: 2013-08-15
-tags: mopidy subsonic cli programming
+tags: 
+- mopidy 
+- subsonic
+- cli 
+- programming
 ---
 
 More info can be found at the [Mopidy-Subsonic](https://github.com/rattboi/mopidy-subsonic) Github page.

--- a/source/_posts/noppoo-keyboard-guide.md
+++ b/source/_posts/noppoo-keyboard-guide.md
@@ -1,7 +1,9 @@
 ---
 title: Noppoo Choc Mini Guide
 date: 2014-08-19
-tags: mechanical keyboard
+tags: 
+- mechanical 
+- keyboard
 ---
 
 ## Introduction

--- a/source/_posts/setting-up-this-blog.md
+++ b/source/_posts/setting-up-this-blog.md
@@ -1,7 +1,9 @@
 ---
 title: Setting Up This Blog
 date: 2012-12-21
-tags: clojure webdev
+tags: 
+- clojure 
+- webdev
 ---
 
 ## Introduction

--- a/source/_posts/songkick-api.md
+++ b/source/_posts/songkick-api.md
@@ -1,7 +1,10 @@
 ---
 title: Using Songkick API in Javascript
 date: 2013-09-01
-tags: webdev music javascript
+tags: 
+- webdev 
+- music 
+- javascript
 ---
 
 [Songkick](https://www.songkick.com/) is a music service that finds local concerts based on your personal tastes. You give it some info about what you like, either through an exported iTunes library, Pandora playlist, or Last.fm scrobble history, tell it where you're interested in going, and it lets you know who is playing and where. I've been a happy user for at least two years now, and it's a really good tool for tracking tours and [concert history.](https://www.songkick.com/users/rattboi/gigography)


### PR DESCRIPTION
When porting the posts from misaki, I didn't realize that space
separating the tags wasn't enough for hexo. I've rectified this by
adding them all as yaml lists.