### PR TITLE
Remove old deploy scripts used by misaki

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-if [ "${TRAVIS_BRANCH}" != "master" ];then
-echo "Not master, not publishing";
-    exit 0;
-fi
-
-bin/expect-rsync.sh | grep -v spawn | grep -v RSA | grep -v Password

--- a/bin/expect-rsync.sh
+++ b/bin/expect-rsync.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/expect -f
-set timeout -1
-spawn rsync -e "ssh -o StrictHostKeyChecking=no" -arvuz public_html $env(DEPLOY_USERNAME)@$env(DEPLOY_HOST):$env(DEPLOY_REMOTEDIR)
-expect -exact "$env(DEPLOY_USERNAME)@$env(DEPLOY_HOST)'s password: "
-send -- "$env(DEPLOY_PASSWORD)\r"
-expect {\$\s*} { interact }


### PR DESCRIPTION
These scripts don't make sense anymore, because I'm able to consolidate
all the deploy code into the travis config now.